### PR TITLE
feat: replace fetchival with a rewritten version

### DIFF
--- a/fetchival.browser.js
+++ b/fetchival.browser.js
@@ -1,1 +1,56 @@
-module.exports = require('fetchival')
+// Based on https://github.com/typicode/fetchival and aims to keep most of the same API
+
+// Unlike fetchival, we also encode the keys
+function query(params) {
+  if (!params) return ''
+  return `?${Object.entries(params)
+    .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+    .join('&')}`
+}
+
+async function _fetch(method, url, opts, data) {
+  // Unlike fetchival, don't silently ignore and override
+  if (opts.body) throw new Error('unexpected pre-set body option')
+
+  // Unlike fetchival, don't pollute the opts object we were given
+  const res = await fetchival.fetch(url, {
+    ...opts,
+    method,
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      ...(opts.headers || {}),
+    },
+    ...(data ? { body: JSON.stringify(data) } : {}),
+  })
+
+  if (res.status >= 200 && res.status < 300) {
+    if (opts.responseAs == 'response') return res
+    if (res.status == 204) return null
+    if (opts.responseAs == 'text') return res.text()
+    return res.json()
+  }
+
+  const err = new Error(res.statusText)
+  err.response = res
+  throw err
+}
+
+function fetchival(url, opts = {}) {
+  const _ = (sub, o = {}) => {
+    // TODO: validate subpath here
+    return fetchival(`${url}/${sub}`, { ...opts, ...o })
+  }
+
+  _.get = (params) => _fetch('GET', url + query(params), opts)
+  _.post = (data) => _fetch('POST', url, opts, data)
+  _.put = (data) => _fetch('PUT', url, opts, data)
+  _.patch = (data) => _fetch('PATCH', url, opts, data)
+  _.delete = () => _fetch('DELETE', url, opts)
+
+  return _
+}
+
+fetchival.fetch = typeof fetch !== 'undefined' ? fetch.bind(globalThis) : null
+
+module.exports = fetchival

--- a/index.browser.js
+++ b/index.browser.js
@@ -3,6 +3,6 @@
 // Don't need to require node-fetch here, global fetch is defined
 // Same for global WebSocket
 
-const fetchival = require('fetchival')
+const fetchival = require('./fetchival.browser.js')
 
 module.exports = { fetch, WebSocket, fetchival }

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
   "author": "Exodus",
   "license": "MIT",
   "dependencies": {
-    "fetchival": "^0.3.3",
     "node-fetch": "^2.6.0",
     "wretch": "^1.5.2",
     "ws": "^6.1.0"


### PR DESCRIPTION
The aim is to add more safeguards and stop using unsupported upstream `fetchival` at all.

Functional differences between fetchival and this impl are documented in the code:
1. Also `encodeURIComponent` the parameter keys, otherwise we can get a problem
2. Don't pollute the options object that was passed in
3. Don't silently ignore the `body` option (fetchival was polluting but ignoring it, we don't pollute and throw instead of ignoring)

Also we will verify that the subpath doesn't contain e.g. `..`, but that will be done in a separate PR