### PR TITLE
feat: createFetchWithHeaders

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,5 +5,6 @@
 const fetch = require('./fetch')
 const WebSocket = require('./websocket')
 const fetchival = require('./fetchival')
+const { createFetchWithHeaders } = require('./with-headers')
 
-module.exports = { fetch, WebSocket, fetchival }
+module.exports = { fetch, WebSocket, fetchival, createFetchWithHeaders }

--- a/test/with-headers.test.js
+++ b/test/with-headers.test.js
@@ -1,0 +1,22 @@
+'use strict'
+
+const tape = require('tape')
+const { createFetchWithHeaders } = require('../with-headers')
+
+tape('createFetchWithHeaders', (t) => {
+  const url = 'https://jsonplaceholder.typicode.com'
+  const fetch = createFetchWithHeaders({
+    fetch: async (url, opts) => ({ url, opts }),
+    headers: { 'x-test': 123 },
+  })
+
+  t.test('adds headers', async (t) => {
+    const res = await fetch(url)
+    t.deepEquals(res, { url, opts: { headers: { 'x-test': 123 } } })
+  })
+
+  t.test(`allows overriding headers`, async (t) => {
+    const res = await fetch(url, { headers: { 'x-test': 456 } })
+    t.deepEquals(res, { url, opts: { headers: { 'x-test': 456 } } })
+  })
+})

--- a/with-headers.js
+++ b/with-headers.js
@@ -1,0 +1,10 @@
+exports.createFetchWithHeaders =
+  ({ fetch, headers }) =>
+  (url, opts = {}) =>
+    fetch(url, {
+      ...opts,
+      headers: {
+        ...headers,
+        ...opts.headers,
+      },
+    })


### PR DESCRIPTION
example use case: creating app-global fetch instances or test-suite-global fetch instances in integration tests with headers our infra expects

open to alternative approaches