### PR TITLE
chore: release 1.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@exodus/fetch",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@exodus/fetch",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "node-fetch": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exodus/fetch",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Wrapper around global fetch / node-fetch for Electron and React",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Manually releasing 1.3.1 since the [ci had issues](https://github.com/ExodusMovement/fetch/actions/runs/9124605045/job/25089106183#step:5:323) with the npm token. It already created a faulty tag, which I will update after merging.

Note: I am raising the [issue](https://exodusio.slack.com/archives/C8P520J6M/p1715931431314159) to devops