### PR TITLE
feat: prefer global fetch on Node.js

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -12,7 +12,7 @@ if (typeof process !== 'undefined' && process) {
     module.exports = fetch
   } else {
     // Node.js or Electron browser process
-    module.exports = require('node-fetch')
+    module.exports = typeof fetch === 'undefined' ? require('node-fetch') : fetch.bind(globalThis)
   }
 } else {
   // Browser or Electron without Node.js integration

--- a/fetch.native.js
+++ b/fetch.native.js
@@ -1,3 +1,3 @@
 'use strict'
 
-module.exports = typeof fetch === 'undefined' ? require('node-fetch') : fetch
+module.exports = typeof fetch === 'undefined' ? require('node-fetch') : fetch.bind(globalThis)


### PR DESCRIPTION
Native `fetch` is no longer behind the experimental flag since Node.js 18.0.0, and is marked stable since Node.js 21.0.0
And the current impl in v20.11+ is newer then the one in v21.0.0

This leaves the backwards-compat in place with environments with no global fetch, and only prefers it over `node-fetch`

We can remove `node-fetch` fallback in v2 or v1 as we don't really need it anymore and all supported Node.js versions have global fetch