### PR TITLE
drop node-fetch and simplify codebase

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
           cache: 'npm'
       - name: Install dependencies
         run: npm ci --ignore-scripts

--- a/README.md
+++ b/README.md
@@ -1,12 +1,4 @@
 # @exodus/fetch
 
-A small wrapper around global fetch and `node-fetch`:
-
-1. In React Native, global `fetch` is used without importing `node-fetch`
-
-2. In Browser, global `fetch` is used without importing `node-fetch`
-
-3. Otherwise `node-fetch` is imported, but when `window.fetch` is present (e.g. in Electron
-   `renderer` process), it is used.
-
-4. Otherwise (e.g. in Electron `browser` process and Node.js), `node-fetch` is used.
+Using this as a wrapper for `node-fetch` is deprecated,
+since all active Node.js versions implement global `fetch`

--- a/create-fetchival.js
+++ b/create-fetchival.js
@@ -8,7 +8,7 @@ function query(params) {
     .join('&')}`
 }
 
-function createFetchival({ fetch }) {
+function createFetchival({ fetch = require('./fetch') } = {}) {
   async function _fetch(method, url, opts, data) {
     // Unlike fetchival, don't silently ignore and override
     if (opts.body) throw new Error('unexpected pre-set body option')

--- a/fetch.browser.js
+++ b/fetch.browser.js
@@ -1,1 +1,0 @@
-module.exports = fetch.bind(globalThis)

--- a/fetch.js
+++ b/fetch.js
@@ -1,20 +1,6 @@
 'use strict'
 
-// This file is structured this way to allow webpack to optimize out
-// the require calls based on hardcoded process.type per bundle.
-// Do not refactor or deduplicate.
+// This is deprecated, just use global fetch instead
+// All supported Node.js versions have it, and the only fallback here was node-fetch
 
-// Try to use global browser APIs (e.g. if in Electron), otherwise require impls
-if (typeof process !== 'undefined' && process) {
-  // Node.js or Electron with Node.js integration
-  if (process.type === 'renderer' || process.type === 'worker') {
-    // Electron renderer with Node.js integration
-    module.exports = fetch
-  } else {
-    // Node.js or Electron browser process
-    module.exports = typeof fetch === 'undefined' ? require('node-fetch') : fetch.bind(globalThis)
-  }
-} else {
-  // Browser or Electron without Node.js integration
-  module.exports = fetch
-}
+module.exports = globalThis.fetch.bind(globalThis)

--- a/fetch.native.js
+++ b/fetch.native.js
@@ -1,3 +1,0 @@
-'use strict'
-
-module.exports = typeof fetch === 'undefined' ? require('node-fetch') : fetch.bind(globalThis)

--- a/fetchival.browser.js
+++ b/fetchival.browser.js
@@ -1,5 +1,0 @@
-const createFetchival = require('./create-fetchival')
-
-module.exports = createFetchival({
-  fetch: typeof fetch === 'undefined' ? null : fetch.bind(globalThis),
-})

--- a/fetchival.js
+++ b/fetchival.js
@@ -1,6 +1,3 @@
-const fetchival = require('./fetchival.browser')
-const fetch = require('./fetch')
+const createFetchival = require('./create-fetchival')
 
-if (!fetchival.fetch) fetchival.fetch = fetch
-
-module.exports = fetchival
+module.exports = createFetchival()

--- a/index.browser.js
+++ b/index.browser.js
@@ -1,9 +1,10 @@
 'use strict'
 
-// Don't need to require node-fetch here, global fetch is defined
-// Same for global WebSocket
+// NOTE: use targeted imports in new code, main import is deprecated
 
-const fetchival = require('./fetchival.browser.js')
-const fetch = require('./fetch.browser.js')
+// Don't need to require ws here, global WebSocket is defined
+
+const fetchival = require('./fetchival.js')
+const fetch = require('./fetch.js')
 
 module.exports = { fetch, WebSocket, fetchival }

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-// NOTE: use targeted imports in new code
+// NOTE: use targeted imports in new code, main import is deprecated
 
 const fetch = require('./fetch')
 const WebSocket = require('./websocket')

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
-        "node-fetch": "^2.6.0",
         "wretch": "^1.5.2",
         "ws": "^6.1.0"
       },
@@ -5056,24 +5055,6 @@
       "dev": true,
       "dependencies": {
         "lodash": "^4.17.21"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
       }
     },
     "node_modules/normalize-package-data": {
@@ -10386,10 +10367,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "license": "MIT"
-    },
     "node_modules/traverse": {
       "version": "0.6.7",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.7.tgz",
@@ -10653,18 +10630,6 @@
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
-      }
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {
@@ -14420,12 +14385,6 @@
         "lodash": "^4.17.21"
       }
     },
-    "node-fetch": {
-      "version": "2.7.0",
-      "requires": {
-        "whatwg-url": "^5.0.0"
-      }
-    },
     "normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -18018,9 +17977,6 @@
         "is-number": "^7.0.0"
       }
     },
-    "tr46": {
-      "version": "0.0.3"
-    },
     "traverse": {
       "version": "0.6.7",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.7.tgz",
@@ -18202,16 +18158,6 @@
       "requires": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
-      }
-    },
-    "webidl-conversions": {
-      "version": "3.0.1"
-    },
-    "whatwg-url": {
-      "version": "5.0.0",
-      "requires": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -17,80 +17,38 @@
       "node": "./index.js",
       "default": "./index.js"
     },
-    "./fetch": {
-      "browser": "./fetch.browser.js",
-      "react-native": "./fetch.native.js",
-      "node": "./fetch.js",
-      "default": "./fetch.js"
-    },
+    "./fetch": "./fetch.js",
     "./websocket": {
       "browser": "./websocket.browser.js",
       "react-native": "./websocket.native.js",
       "node": "./websocket.js",
       "default": "./websocket.js"
     },
-    "./core": {
-      "browser": "./core.js",
-      "react-native": "./core.js",
-      "node": "./core.js",
-      "default": "./core.js"
-    },
-    "./experimental/fetchival": {
-      "browser": "./experimental/fetchival.js",
-      "react-native": "./experimental/fetchival.js",
-      "node": "./experimental/fetchival.js",
-      "default": "./experimental/fetchival.js"
-    },
-    "./experimental/create-fetchival": {
-      "default": "./experimental/create-fetchival.js"
-    },
-    "./fetchival": {
-      "browser": "./fetchival.browser.js",
-      "react-native": "./fetchival.js",
-      "node": "./fetchival.js",
-      "default": "./fetchival.js"
-    },
-    "./create-fetchival": {
-      "default": "./create-fetchival.js"
-    },
-    "./wretch": {
-      "browser": "./wretch.browser.js",
-      "react-native": "./wretch.js",
-      "node": "./wretch.js",
-      "default": "./wretch.js"
-    },
-    "./url": {
-      "browser": "./url.js",
-      "react-native": "./url.js",
-      "node": "./url.js",
-      "default": "./url.js"
-    }
+    "./core": "./core.js",
+    "./experimental/fetchival": "./experimental/fetchival.js",
+    "./experimental/create-fetchival": "./experimental/create-fetchival.js",
+    "./fetchival": "./fetchival.js",
+    "./create-fetchival": "./create-fetchival.js",
+    "./wretch": "./wretch.js",
+    "./url": "./url.js"
   },
   "browser": {
-    "./fetchival.js": "./fetchival.browser.js",
-    "./wretch.js": "./wretch.browser.js",
-    "./fetch.js": "./fetch.browser.js",
     "./websocket.js": "./websocket.browser.js",
     "./index.js": "./index.browser.js"
   },
   "react-native": {
-    "./fetch.js": "./fetch.native.js",
     "./websocket.js": "./websocket.native.js"
   },
   "files": [
     "experimental/fetchival.js",
     "experimental/create-fetchival.js",
     "core.js",
-    "fetch.browser.js",
-    "fetch.native.js",
     "fetch.js",
     "websocket.browser.js",
     "websocket.native.js",
     "websocket.js",
     "create-fetchival.js",
-    "fetchival.browser.js",
     "fetchival.js",
-    "wretch.browser.js",
     "wretch.js",
     "url.js",
     "index.browser.js",
@@ -107,7 +65,6 @@
   "author": "Exodus Movement Inc.",
   "license": "MIT",
   "dependencies": {
-    "node-fetch": "^2.6.0",
     "wretch": "^1.5.2",
     "ws": "^6.1.0"
   },

--- a/wretch.browser.js
+++ b/wretch.browser.js
@@ -1,1 +1,0 @@
-module.exports = require('wretch')

--- a/wretch.js
+++ b/wretch.js
@@ -1,7 +1,1 @@
-// NOTE: does not export Wretcher
-const wretch = require('./wretch.browser')
-const fetch = require('./fetch')
-
-wretch().polyfills({ fetch })
-
-module.exports = wretch
+module.exports = require('wretch')


### PR DESCRIPTION
This would have been a semver-major, but I propose to treat Node.js versions unsupported by upstream as unsupported here even in terms of semver-major breakages

Then, `node-fetch` is not actually used on any platform since #20, so it can be removed, and code simplified