### PR TITLE
fix: regression from fetchival unification

### DIFF
--- a/experimental/create-fetchival.js
+++ b/experimental/create-fetchival.js
@@ -8,7 +8,7 @@ function createFetchival({ fetch = require('../fetch') } = {}) {
     if (opts.body) throw new Error('unexpected pre-set body option')
 
     // Unlike fetchival, don't pollute the opts object we were given
-    const res = await fetchival.fetch(url, {
+    const res = await fetchival.fetch(link, {
       timeout: 30_000, // default timeout to 30s, unlike fetchival or fetch
       ...opts,
       method,

--- a/test/fetchival.experimental.js
+++ b/test/fetchival.experimental.js
@@ -1,0 +1,50 @@
+const tape = require('tape')
+const fetchival = require('../experimental/fetchival')
+
+function Captor() {
+  const captor = {
+    calls: [],
+    async capture(...args) {
+      this.calls.push(args)
+      return { status: 204 }
+    },
+  }
+  const capture = captor.capture.bind(captor)
+  capture.calls = captor.calls
+
+  return capture
+}
+
+tape('fetchival', (t) => {
+  t.test('fetches json', async () => {
+    const res = await fetchival(new URL('https://jsonplaceholder.typicode.com'))('posts').get()
+
+    t.equals(res.length, 100)
+  })
+
+  t.test('fetchival concatenates subpath with base URL', async (t) => {
+    const captor = Captor()
+    fetchival.fetch = captor
+
+    const client = fetchival(new URL('https://wayne-foundation.com'))('register')
+
+    await client.post({ some: 'data' })
+
+    const [url] = captor.calls[0]
+
+    t.deepEqual(url, new URL('https://wayne-foundation.com/register'))
+  })
+
+  t.test('fetchival concatenates subpath with string base URL', async (t) => {
+    const captor = Captor()
+    fetchival.fetch = captor
+
+    const client = fetchival(new URL('https://wayne-foundation.com'))('register')
+
+    await client.post({ some: 'data' })
+
+    const [url] = captor.calls[0]
+
+    t.deepEqual(url, new URL('https://wayne-foundation.com/register'))
+  })
+})


### PR DESCRIPTION
Whoops

Broken in https://github.com/ExodusMovement/fetch/pull/19/files#diff-811736ce017df3875fb1cf62e24a906d3ff609abe197fbafd6873321333eb187R11

Also adds tests copied from [test/fetchival.js](https://github.com/ExodusMovement/fetch/blob/master/test/fetchival.js) with with adjustments for URL instances