### PR TITLE
feat: don't store bound global fetch

### DIFF
--- a/fetch.browser.js
+++ b/fetch.browser.js
@@ -1,1 +1,1 @@
-module.exports = fetch.bind(globalThis)
+module.exports = (i, ...r) => globalThis.fetch(i, ...r)

--- a/fetch.js
+++ b/fetch.js
@@ -9,12 +9,18 @@ if (typeof process !== 'undefined' && process) {
   // Node.js or Electron with Node.js integration
   if (process.type === 'renderer' || process.type === 'worker') {
     // Electron renderer with Node.js integration
-    module.exports = fetch
+    module.exports = (i, ...r) => globalThis.fetch(i, ...r)
   } else {
     // Node.js or Electron browser process
-    module.exports = typeof fetch === 'undefined' ? require('node-fetch') : fetch.bind(globalThis)
+    if (typeof fetch === 'undefined') {
+      // Fall back to node-fetch
+      module.exports = require('node-fetch')
+    } else {
+      // Prefer Node.js fetch if exists
+      module.exports = (i, ...r) => globalThis.fetch(i, ...r)
+    }
   }
 } else {
   // Browser or Electron without Node.js integration
-  module.exports = fetch
+  module.exports = (i, ...r) => globalThis.fetch(i, ...r)
 }

--- a/fetch.native.js
+++ b/fetch.native.js
@@ -1,3 +1,9 @@
 'use strict'
 
-module.exports = typeof fetch === 'undefined' ? require('node-fetch') : fetch.bind(globalThis)
+if (typeof fetch === 'undefined') {
+  // Fall back to node-fetch
+  module.exports = require('node-fetch')
+} else {
+  // Prefer native / Node.js fetch if exists
+  module.exports = (i, ...r) => globalThis.fetch(i, ...r)
+}

--- a/fetchival.browser.js
+++ b/fetchival.browser.js
@@ -1,5 +1,5 @@
 const createFetchival = require('./create-fetchival')
 
 module.exports = createFetchival({
-  fetch: typeof fetch === 'undefined' ? null : fetch.bind(globalThis),
+  fetch: typeof fetch === 'undefined' ? null : (i, ...r) => globalThis.fetch(i, ...r),
 })


### PR DESCRIPTION
This way it will pick up global fetch changes instead of caching the value

```console
> const f = require('@exodus/fetch').fetch
undefined
> globalThis.fetch = () => 40
[Function (anonymous)]
> f()
40
```

This makes it overridable globally instead of having to assign to each instance (which might be many, as this isn't a singleton and was never intended to be)