### PR TITLE
fix: wretch default export compatibility in CommonJS

### DIFF
--- a/wretch.js
+++ b/wretch.js
@@ -1,5 +1,5 @@
 // NOTE: does not export Wretcher
-const wretch = require('./wretch.browser')
+const { default: wretch } = require('./wretch.browser')
 const fetch = require('./fetch')
 
 wretch().polyfills({ fetch })


### PR DESCRIPTION
## Summary
This PR fixes the issue where `wretch` was being called as a function but threw an error ([wretch is not a function](https://exodusio.slack.com/archives/C019BPCLTPT/p1741377464444099?thread_ts=1741359662.414859&cid=C019BPCLTPT)). 

<img width="921" alt="Screenshot 2025-03-08 at 03 41 41" src="https://github.com/user-attachments/assets/2726feca-f03d-4db4-92d6-ee0865512f57" />

The issue occurred because `wretch.browser.js` exports wretch as an ESModule default export, and when imported via `require`, the default export is wrapped inside a `.default` property. This fix explicitly accesses the `.default` property when importing `wretch.browser.js` in `wretch.js`, ensuring compatibility with CommonJS.

Tested on integration tests of `tron-api`, `solana-api`
