### PR TITLE
fix: unbreak bundling wretch

### DIFF
--- a/wretch.browser.js
+++ b/wretch.browser.js
@@ -1,1 +1,4 @@
-module.exports = require('wretch')
+const { default: wretch } = require('wretch')
+
+// Removes the .default property from the exported function to deconfuse bundlers
+module.exports = (url, options) => wretch(url, options)

--- a/wretch.js
+++ b/wretch.js
@@ -1,5 +1,5 @@
 // NOTE: does not export Wretcher
-const { default: wretch } = require('./wretch.browser')
+const wretch = require('./wretch.browser')
 const fetch = require('./fetch')
 
 wretch().polyfills({ fetch })


### PR DESCRIPTION
The current wretch logic is still broken with bundlers, even on 1.7.4.

See #32.

> The issue occurred because `wretch.browser.js` exports wretch as an ESModule default export, and when imported via `require`, the default export is wrapped inside a `.default` property. This fix explicitly accesses the `.default` property when importing `wretch.browser.js` in `wretch.js`, ensuring compatibility with CommonJS.

That's not the case, `wretch.browser.js` is CJS, not ESM.

The real issue is that `require('wretch')` is a function with `x.default = x`, so each time it's imported (either from `'wretch'`, `./wretch.browswer.js`, `./wretch.js` or anywhere else) some bundlers get confused and unwrap that to an object `{ default : x }` instead of a function.

The only way to break that loop is to wrap the function, removing it's `.default` property.

This reverts the change from #32 and instead does that.