### PR TITLE
fix: remove doubled slash when using URL instance

### DIFF
--- a/test/url.js
+++ b/test/url.js
@@ -36,6 +36,10 @@ tape('url', (t) => {
     const arg = new Map(Object.entries({ x: 10, b: 20 }))
     check(url`https://example.org/buz/?d&${arg}`, 'https://example.org/buz/?d&x=10&b=20')
   })
+  t.doesNotThrow(() => {
+    const baseUrl = new URL('https://example.org')
+    check(url`${baseUrl}/foo`, 'https://example.org/foo')
+  })
 
   t.end()
 })

--- a/test/url.js
+++ b/test/url.js
@@ -40,6 +40,21 @@ tape('url', (t) => {
     const baseUrl = new URL('https://example.org')
     check(url`${baseUrl}/foo`, 'https://example.org/foo')
   })
+  t.doesNotThrow(() => {
+    // baseURL ends with / and endpoint does too.
+    const baseUrl = new URL('https://example.org/')
+    check(url`${baseUrl}/foo`, 'https://example.org/foo')
+  })
+  t.doesNotThrow(() => {
+    // baseURL ends with / but endpoint doesn't.
+    const baseUrl = new URL('https://example.org/')
+    check(url`${baseUrl}foo`, 'https://example.org/foo')
+  })
+  t.doesNotThrow(() => {
+    // baseURL doesn't ends with / and endpoint doesn't.
+    const baseUrl = new URL('https://example.org')
+    check(url`${baseUrl}foo`, 'https://example.org/foo')
+  })
 
   t.end()
 })

--- a/url.js
+++ b/url.js
@@ -96,7 +96,30 @@ function url(strings, ...args) {
 
     return encodeComponent(raw)
   })
-  const res = [strings[0], ...escaped.flatMap((arg, i) => [arg, strings[i + 1]])].join('')
+
+  // Handle the case where a URL object is used as base and creates double slashes
+  let res
+
+  if (base && escaped.length > 0) {
+    const parts = [strings[0]]
+
+    for (const [i, escapedArg] of escaped.entries()) {
+      parts.push(escapedArg)
+      let nextString = strings[i + 1]
+
+      // If the previous part ends with '/' and next string starts with '/', remove the duplicate
+      if (parts[parts.length - 1].endsWith('/') && nextString.startsWith('/')) {
+        nextString = nextString.slice(1)
+      }
+
+      parts.push(nextString)
+    }
+
+    res = parts.join('')
+  } else {
+    res = [strings[0], ...escaped.flatMap((arg, i) => [arg, strings[i + 1]])].join('')
+  }
+
   if (base) validateBase(base, res)
   const url = new URL(res)
   if (String(url) !== res) throw new Error('Unexpected URL produced!') // e.g. .. which get resolved


### PR DESCRIPTION
The test I added fails in master since the url is `https://example.org//foo`.

The doubled `//` ad the end makes fetch fails.

(note: I used AI to fix the issue, so please evaluate if anything else is needed)
