### PR TITLE
fix: add res.status to error message

### DIFF
--- a/create-fetchival.js
+++ b/create-fetchival.js
@@ -32,7 +32,7 @@ function createFetchival({ fetch }) {
       return res.json()
     }
 
-    const err = new Error(res.statusText)
+    const err = new Error(`${res.status} ${res.statusText || ''}`)
     err.response = res
     throw err
   }

--- a/create-fetchival.js
+++ b/create-fetchival.js
@@ -32,7 +32,7 @@ function createFetchival({ fetch }) {
       return res.json()
     }
 
-    const err = new Error(`${res.status} ${res.statusText || ''}`)
+    const err = new Error(`${res.status} ${res.statusText || ''}`.trim())
     err.response = res
     throw err
   }


### PR DESCRIPTION
cause res.statusText can be undefined


<img width="237" height="183" alt="SCR-20250912-lylk" src="https://github.com/user-attachments/assets/3955d16b-d6d9-4b04-8433-c98740be5979" />
