### PR TITLE
fix: prevent JSON.stringify on non-JSON payloads

### DIFF
--- a/create-fetchival.js
+++ b/create-fetchival.js
@@ -13,16 +13,20 @@ function createFetchival({ fetch }) {
     // Unlike fetchival, don't silently ignore and override
     if (opts.body) throw new Error('unexpected pre-set body option')
 
+    const headers = {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      ...opts.headers,
+    }
+    // If a consumer has set the non-json content type, we don't stringify the body.
+    const shouldStringify = headers['Content-Type'] === 'application/json'
+
     // Unlike fetchival, don't pollute the opts object we were given
     const res = await fetchival.fetch(url, {
       ...opts,
       method,
-      headers: {
-        Accept: 'application/json',
-        'Content-Type': 'application/json',
-        ...opts.headers,
-      },
-      ...(data ? { body: JSON.stringify(data) } : {}),
+      headers,
+      ...(data ? { body: shouldStringify ? JSON.stringify(data) : data } : {}),
     })
 
     if (res.status >= 200 && res.status < 300) {

--- a/create-fetchival.js
+++ b/create-fetchival.js
@@ -8,6 +8,8 @@ function query(params) {
     .join('&')}`
 }
 
+const prevenJsonStringifyContentTypes = new Set(['application/x-sentry-envelope'])
+
 function createFetchival({ fetch }) {
   async function _fetch(method, url, opts, data) {
     // Unlike fetchival, don't silently ignore and override
@@ -18,8 +20,8 @@ function createFetchival({ fetch }) {
       'Content-Type': 'application/json',
       ...opts.headers,
     }
-    // If a consumer has set the non-json content type, we don't stringify the body.
-    const shouldStringify = headers['Content-Type'] === 'application/json'
+    // Allows some consumers to avoid JSON.stringify for their vendor-specific content types.
+    const shouldStringify = !prevenJsonStringifyContentTypes.has(headers['Content-Type'])
 
     // Unlike fetchival, don't pollute the opts object we were given
     const res = await fetchival.fetch(url, {

--- a/test/create-fetchival.js
+++ b/test/create-fetchival.js
@@ -32,7 +32,7 @@ tape('createFetchival', (t) => {
     }
   })
 
-  t.test('does not stringify body when Content-Type is not application/json', async (t) => {
+  t.test('does not stringify body for specific Conent-Type headers', async (t) => {
     let capturedOpts
     const formData = 'name=John&age=30'
     const fetch = async (url, opts) => {
@@ -44,7 +44,7 @@ tape('createFetchival', (t) => {
 
     await fetchival('https://example.com')('api', {
       headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
+        'Content-Type': 'application/x-sentry-envelope',
       },
     }).post(formData)
 
@@ -53,7 +53,7 @@ tape('createFetchival', (t) => {
       formData,
       'body should not be stringified for non-JSON content type'
     )
-    t.equals(capturedOpts.headers['Content-Type'], 'application/x-www-form-urlencoded')
+    t.equals(capturedOpts.headers['Content-Type'], 'application/x-sentry-envelope')
   })
 
   t.test('applies JSON.stringify to body by default', async (t) => {

--- a/test/create-fetchival.js
+++ b/test/create-fetchival.js
@@ -31,4 +31,28 @@ tape('createFetchival', (t) => {
       t.equals(err.message, 'Couldnt establish connection')
     }
   })
+
+  t.test('does not stringify body when Content-Type is not application/json', async (t) => {
+    let capturedOpts
+    const formData = 'name=John&age=30'
+    const fetch = async (url, opts) => {
+      capturedOpts = opts
+      return { status: 200, json: async () => ({ success: true }) }
+    }
+
+    const fetchival = createFetchival({ fetch })
+
+    await fetchival('https://example.com')('api', {
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+    }).post(formData)
+
+    t.equals(
+      capturedOpts.body,
+      formData,
+      'body should not be stringified for non-JSON content type'
+    )
+    t.equals(capturedOpts.headers['Content-Type'], 'application/x-www-form-urlencoded')
+  })
 })

--- a/test/create-fetchival.js
+++ b/test/create-fetchival.js
@@ -55,4 +55,24 @@ tape('createFetchival', (t) => {
     )
     t.equals(capturedOpts.headers['Content-Type'], 'application/x-www-form-urlencoded')
   })
+
+  t.test('applies JSON.stringify to body by default', async (t) => {
+    let capturedOpts
+    const formData = 'name=John&age=30'
+    const fetch = async (url, opts) => {
+      capturedOpts = opts
+      return { status: 200, json: async () => ({ success: true }) }
+    }
+
+    const fetchival = createFetchival({ fetch })
+
+    await fetchival('https://example.com')('api').post(formData)
+
+    t.equals(
+      capturedOpts.body,
+      JSON.stringify(formData),
+      'body should not be stringified for non-JSON content type'
+    )
+    t.equals(capturedOpts.headers['Content-Type'], 'application/json')
+  })
 })


### PR DESCRIPTION
In some scenarios (like [this one](https://github.com/ExodusMovement/exodus-hydra/pull/13952/files#diff-f61390b1f3f8eac118671dcc34c4ddae6f02a4ab31027e04b270b7dd400ab5fbR90)) we want to use non `application/json` payload. `JSON.stringify` breaks the payload in that case by adding escape characters 


## Testing

- [x] CI